### PR TITLE
fix next start date calculation for same month

### DIFF
--- a/lib/__tests__/programDates.test.js
+++ b/lib/__tests__/programDates.test.js
@@ -21,6 +21,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
       ttt.true((0, _util.momentDayOnly)(sd).isSame(expected), 'should be 2017-04-17');
     });
 
+    tt.test('returns first Monday of same month if still in the future', function (ttt) {
+      ttt.plan(1);
+      var sd = (0, _programDates.nextStartDate)('2017-08-03');
+      var expected = (0, _util.momentDayOnly)('2017-08-07');
+      ttt.true((0, _util.momentDayOnly)(sd).isSame(expected), 'should be first Monday of same month');
+    });
+
     tt.test('returns first Monday of next month if not a holiday', function (ttt) {
       ttt.plan(1);
       var sd = (0, _programDates.nextStartDate)('2017-09-15');

--- a/lib/programDates.js
+++ b/lib/programDates.js
@@ -28,19 +28,26 @@ var _legacyStartDate = function _legacyStartDate(date) {
 var nextStartDate = exports.nextStartDate = function nextStartDate() {
   var date = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : new Date();
 
-  var input = (0, _util.momentDayOnly)(date);
-  if (input.isBefore(_legacyStartDates[_legacyStartDates.length - 1])) {
-    return _legacyStartDate(date);
+  var inputDate = (0, _util.momentDayOnly)(date);
+  if (inputDate.isBefore(_legacyStartDates[_legacyStartDates.length - 1])) {
+    return _legacyStartDate(inputDate);
   }
 
-  var firstMondayNextMonth = input.clone().endOf('month').endOf('isoWeek').add(1, 'day');
-  var output = (0, _util.momentDayOnly)(firstMondayNextMonth);
-
-  while ((0, _holidays.isHoliday)(output) || (0, _breakWeeks.isDuringBreakWeek)(output) || output.day() === 0 || output.day() === 6) {
-    output.add(1, 'day');
+  var startDate = void 0;
+  var firstMondayMonth = _firstMondayOfMonth(inputDate);
+  var firstMondayMonthInFuture = firstMondayMonth.date() >= inputDate.date();
+  if (firstMondayMonthInFuture) {
+    startDate = firstMondayMonth;
+  } else {
+    var firstDayNextMonth = inputDate.clone().endOf('month').add(1, 'day');
+    startDate = _firstMondayOfMonth(firstDayNextMonth);
   }
 
-  return output.toDate();
+  while ((0, _holidays.isHoliday)(startDate) || (0, _breakWeeks.isDuringBreakWeek)(startDate) || startDate.isoWeekday() === 6 || startDate.isoWeekday() === 7) {
+    startDate.add(1, 'day');
+  }
+
+  return startDate.toDate();
 };
 var defaultStartDate = exports.defaultStartDate = nextStartDate();
 
@@ -151,3 +158,7 @@ var stipendPaymentDatesBetween = exports.stipendPaymentDatesBetween = function s
     return m.toDate();
   });
 };
+
+function _firstMondayOfMonth(date) {
+  return (0, _util.momentDayOnly)(date.clone().startOf('month').startOf('isoWeek').add(7, 'day'));
+}

--- a/src/__tests__/programDates.test.js
+++ b/src/__tests__/programDates.test.js
@@ -29,6 +29,13 @@ test('src/programDates', t => {
       ttt.true(momentDayOnly(sd).isSame(expected), 'should be 2017-04-17')
     })
 
+    tt.test('returns first Monday of same month if still in the future', ttt => {
+      ttt.plan(1)
+      const sd = nextStartDate('2017-08-03')
+      const expected = momentDayOnly('2017-08-07')
+      ttt.true(momentDayOnly(sd).isSame(expected), 'should be first Monday of same month')
+    })
+
     tt.test('returns first Monday of next month if not a holiday', ttt => {
       ttt.plan(1)
       const sd = nextStartDate('2017-09-15')

--- a/src/programDates.js
+++ b/src/programDates.js
@@ -41,27 +41,30 @@ const _legacyStartDate = date => {
 }
 
 export const nextStartDate = (date = new Date()) => {
-  const input = momentDayOnly(date)
-  if (input.isBefore(_legacyStartDates[_legacyStartDates.length - 1])) {
-    return _legacyStartDate(date)
+  const inputDate = momentDayOnly(date)
+  if (inputDate.isBefore(_legacyStartDates[_legacyStartDates.length - 1])) {
+    return _legacyStartDate(inputDate)
   }
 
-  const firstMondayNextMonth = input
-    .clone()
-    .endOf('month')
-    .endOf('isoWeek')
-    .add(1, 'day')
-  const output = momentDayOnly(firstMondayNextMonth)
+  let startDate
+  const firstMondayMonth = _firstMondayOfMonth(inputDate)
+  const firstMondayMonthInFuture = firstMondayMonth.date() >= inputDate.date()
+  if (firstMondayMonthInFuture) {
+    startDate = firstMondayMonth
+  } else {
+    const firstDayNextMonth = inputDate.clone().endOf('month').add(1, 'day')
+    startDate = _firstMondayOfMonth(firstDayNextMonth)
+  }
 
   while (
-    isHoliday(output) ||
-    isDuringBreakWeek(output) ||
-    output.day() === 0 ||
-    output.day() === 6) {
-    output.add(1, 'day')
+    isHoliday(startDate) ||
+    isDuringBreakWeek(startDate) ||
+    startDate.isoWeekday() === 6 ||
+    startDate.isoWeekday() === 7) {
+    startDate.add(1, 'day')
   }
 
-  return output.toDate()
+  return startDate.toDate()
 }
 export const defaultStartDate = nextStartDate()
 
@@ -177,4 +180,14 @@ export const stipendPaymentDatesBetween = (startDate, endDate) => {
     stipendPaymentDate.add(2, 'weeks')
   }
   return paymentDates.map(m => m.toDate())
+}
+
+function _firstMondayOfMonth(date) {
+  return momentDayOnly(
+    date
+      .clone()
+      .startOf('month')
+      .startOf('isoWeek')
+      .add(7, 'day')
+  )
 }


### PR DESCRIPTION
Fixes https://github.com/LearnersGuild/isa-calculator/issues/14.

Fixes an issue with default start date calculation when the next start date is in the current month.