### PR TITLE
Fix date timezone conversion issue

### DIFF
--- a/lib/__tests__/holidays.test.js
+++ b/lib/__tests__/holidays.test.js
@@ -17,7 +17,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
     tt.test('returns next New Year\'s day if no date is given', function (ttt) {
       ttt.plan(1);
       var nextNewYears = (0, _holidays.newYearsDay)();
-      var expected = (0, _util.momentDayOnly)(new Date(new Date().getFullYear() + 1, 0, 1));
+      var now = new Date();
+      var expectedUTC = Date.UTC(now.getUTCFullYear() + 1, 0, 1);
+      var expected = (0, _util.momentDayOnly)(new Date(expectedUTC));
       ttt.true((0, _util.momentDayOnly)(nextNewYears).isSame(expected), 'should be the next New Year\'s Day');
     });
 

--- a/lib/__tests__/programDates.test.js
+++ b/lib/__tests__/programDates.test.js
@@ -16,23 +16,23 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
     tt.test('returns the legacy start date if before 2017-05-08', function (ttt) {
       ttt.plan(1);
-      var sd = (0, _programDates.nextStartDate)('2017-04-12');
+      var start = (0, _programDates.nextStartDate)('2017-04-12');
       var expected = (0, _util.momentDayOnly)('2017-04-17');
-      ttt.true((0, _util.momentDayOnly)(sd).isSame(expected), 'should be 2017-04-17');
+      ttt.true((0, _util.momentDayOnly)(start).isSame(expected), 'should be 2017-04-17');
     });
 
     tt.test('returns first Monday of next month if not a holiday', function (ttt) {
       ttt.plan(1);
-      var sd = (0, _programDates.nextStartDate)('2017-09-15');
+      var start = (0, _programDates.nextStartDate)('2017-09-15');
       var expected = (0, _util.momentDayOnly)('2017-10-02');
-      ttt.true((0, _util.momentDayOnly)(sd).isSame(expected), 'should be first Monday of next month');
+      ttt.true((0, _util.momentDayOnly)(start).isSame(expected), 'should be first Monday of next month');
     });
 
     tt.test('returns first Tuesday of next month if first Monday falls on a holiday', function (ttt) {
       ttt.plan(1);
-      var sd = (0, _programDates.nextStartDate)('2017-08-15');
+      var start = (0, _programDates.nextStartDate)('2017-08-15');
       var expected = (0, _util.momentDayOnly)('2017-09-05');
-      ttt.true((0, _util.momentDayOnly)(sd).isSame(expected), 'should be first Tuesday of next month');
+      ttt.true((0, _util.momentDayOnly)(start).isSame(expected), 'should be first Tuesday of next month');
     });
   });
 
@@ -42,13 +42,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
     tt.test('returns Friday of (startDate + 41 weeks) if 1 break week is encountered', function (ttt) {
       ttt.plan(1);
       var exit = (0, _programDates.expectedExitDate)(new Date('2017-08-07'));
-      ttt.true((0, _util.momentDayOnly)(exit).isSame('2018-05-18', 'day'), 'should be Friday of 41st week');
+      ttt.true((0, _util.momentDayOnly)(exit).isSame((0, _util.momentDayOnly)('2018-05-18')), 'should be Friday of 41st week');
     });
 
     tt.test('returns Friday of (startDate + 42 weeks) if both break weeks are encountered', function (ttt) {
       ttt.plan(1);
       var exit = (0, _programDates.expectedExitDate)(new Date('2017-05-08'));
-      ttt.true((0, _util.momentDayOnly)(exit).isSame('2018-02-23', 'day'), 'should be Friday of 42nd week');
+      ttt.true((0, _util.momentDayOnly)(exit).isSame((0, _util.momentDayOnly)('2018-02-23')), 'should be Friday of 42nd week');
     });
   });
 
@@ -90,13 +90,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
     tt.test('returns Monday of (startDate + 6) weeks if no break weeks are encountered', function (ttt) {
       ttt.plan(1);
       var cancel = (0, _programDates.isaCancellationDate)(new Date('2017-02-06'));
-      ttt.true((0, _util.momentDayOnly)(cancel).isSame('2017-03-13'), 'should be Monday of 6th week');
+      ttt.true((0, _util.momentDayOnly)(cancel).isSame((0, _util.momentDayOnly)('2017-03-13')), 'should be Monday of 6th week');
     });
 
     tt.test('returns Monday of (startDate + 7) weeks if a break week is encountered', function (ttt) {
       ttt.plan(1);
       var cancel = (0, _programDates.isaCancellationDate)(new Date('2017-12-04'));
-      ttt.true((0, _util.momentDayOnly)(cancel).isSame('2018-01-15'), 'should be Monday of 6th week');
+      ttt.true((0, _util.momentDayOnly)(cancel).isSame((0, _util.momentDayOnly)('2018-01-15')), 'should be Monday of 6th week');
     });
   });
 
@@ -105,9 +105,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
     tt.test('returns the start date of the session (0 indexed) for a given program start date', function (ttt) {
       ttt.plan(3);
-      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionStartDate)(new Date('2016-11-28'), 0)).isSame('2016-11-28'), 'should be Monday of 1st week, not counting break weeks');
-      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionStartDate)(new Date('2016-11-28'), 2)).isSame('2017-03-27'), 'should be Monday of 24th week, not counting break weeks');
-      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionStartDate)(new Date('2016-11-28'), 3)).isSame('2017-05-22'), 'should be Monday of 32nd week, not counting break weeks');
+      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionStartDate)(new Date('2016-11-28'), 0)).isSame((0, _util.momentDayOnly)('2016-11-28')), 'should be Monday of 1st week, not counting break weeks');
+      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionStartDate)(new Date('2016-11-28'), 2)).isSame((0, _util.momentDayOnly)('2017-03-27')), 'should be Monday of 24th week, not counting break weeks');
+      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionStartDate)(new Date('2016-11-28'), 3)).isSame((0, _util.momentDayOnly)('2017-05-22')), 'should be Monday of 32nd week, not counting break weeks');
     });
   });
 
@@ -116,9 +116,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
     tt.test('returns the end date of the session (0 indexed) for a given program start date', function (ttt) {
       ttt.plan(3);
-      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionEndDate)(new Date('2016-11-28'), 0)).isSame('2017-01-27'), 'should be Friday of 8th week, not counting break weeks');
-      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionEndDate)(new Date('2016-11-28'), 2)).isSame('2017-05-19'), 'should be Friday of 24th week, not counting break weeks');
-      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionEndDate)(new Date('2016-11-28'), 3)).isSame('2017-07-21'), 'should be Friday of 32nd week, not counting break weeks');
+      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionEndDate)(new Date('2016-11-28'), 0)).isSame((0, _util.momentDayOnly)('2017-01-27')), 'should be Friday of 8th week, not counting break weeks');
+      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionEndDate)(new Date('2016-11-28'), 2)).isSame((0, _util.momentDayOnly)('2017-05-19')), 'should be Friday of 24th week, not counting break weeks');
+      ttt.true((0, _util.momentDayOnly)((0, _programDates.isaSessionEndDate)(new Date('2016-11-28'), 3)).isSame((0, _util.momentDayOnly)('2017-07-21')), 'should be Friday of 32nd week, not counting break weeks');
     });
   });
 
@@ -127,7 +127,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
     tt.test('returns the number of days in the session (0 indexed) for a given program start date', function (ttt) {
       ttt.plan(1);
-      var numDays = (0, _programDates.numDaysInISASession)(new Date('2016-10-03'), 0);
+      var numDays = (0, _programDates.numDaysInISASession)(new Date(Date.UTC(2016, 9, 3)), 0); // 10/3/16
       ttt.equal(numDays, 36, 'should exclude Indigenous People\'s Day, Veteran\'s Day, and the Thanksgiving holidays');
     });
   });
@@ -137,7 +137,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
     tt.test('returns the stipend payment dates between the given dates', function (ttt) {
       ttt.plan(1);
-      var payments = (0, _programDates.stipendPaymentDatesBetween)(new Date('2017-08-07'), new Date('2017-12-31'));
+      var payments = (0, _programDates.stipendPaymentDatesBetween)(new Date(Date.UTC(2017, 7, 7)), new Date(Date.UTC(2017, 11, 31))); // 8/7/17, 12/31/17
       ttt.equal(payments.length, 10, 'should include 10 stipend payments');
     });
   });

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,11 +16,11 @@ var momentDayOnly = exports.momentDayOnly = function momentDayOnly(date) {
   if (!dayOnly.isValid()) {
     throw new Error(date + ' is not a valid date');
   }
-  return dayOnly.hour(0).minute(0).second(0).millisecond(0);
+  return dayOnly.utc().hour(0).minute(0).second(0).millisecond(0);
 };
 
 var formatDate = exports.formatDate = function formatDate(date) {
-  return (0, _moment2.default)(date).format('ddd DD MMM YYYY');
+  return (0, _moment2.default)(date).utc().format('ddd DD MMM YYYY');
 };
 
 var throwsIfInvalidDate = exports.throwsIfInvalidDate = function throwsIfInvalidDate(func) {

--- a/src/__tests__/holidays.test.js
+++ b/src/__tests__/holidays.test.js
@@ -29,7 +29,9 @@ test('src/holidays', t => {
     tt.test('returns next New Year\'s day if no date is given', ttt => {
       ttt.plan(1)
       const nextNewYears = newYearsDay()
-      const expected = momentDayOnly(new Date((new Date()).getFullYear() + 1, 0, 1))
+      const now = new Date()
+      const expectedUTC = Date.UTC(now.getUTCFullYear() + 1, 0, 1)
+      const expected = momentDayOnly(new Date(expectedUTC))
       ttt.true(momentDayOnly(nextNewYears).isSame(expected), 'should be the next New Year\'s Day')
     })
 

--- a/src/__tests__/programDates.test.js
+++ b/src/__tests__/programDates.test.js
@@ -24,23 +24,23 @@ test('src/programDates', t => {
 
     tt.test('returns the legacy start date if before 2017-05-08', ttt => {
       ttt.plan(1)
-      const sd = nextStartDate('2017-04-12')
+      const start = nextStartDate('2017-04-12')
       const expected = momentDayOnly('2017-04-17')
-      ttt.true(momentDayOnly(sd).isSame(expected), 'should be 2017-04-17')
+      ttt.true(momentDayOnly(start).isSame(expected), 'should be 2017-04-17')
     })
 
     tt.test('returns first Monday of next month if not a holiday', ttt => {
       ttt.plan(1)
-      const sd = nextStartDate('2017-09-15')
+      const start = nextStartDate('2017-09-15')
       const expected = momentDayOnly('2017-10-02')
-      ttt.true(momentDayOnly(sd).isSame(expected), 'should be first Monday of next month')
+      ttt.true(momentDayOnly(start).isSame(expected), 'should be first Monday of next month')
     })
 
     tt.test('returns first Tuesday of next month if first Monday falls on a holiday', ttt => {
       ttt.plan(1)
-      const sd = nextStartDate('2017-08-15')
+      const start = nextStartDate('2017-08-15')
       const expected = momentDayOnly('2017-09-05')
-      ttt.true(momentDayOnly(sd).isSame(expected), 'should be first Tuesday of next month')
+      ttt.true(momentDayOnly(start).isSame(expected), 'should be first Tuesday of next month')
     })
   })
 
@@ -50,13 +50,13 @@ test('src/programDates', t => {
     tt.test('returns Friday of (startDate + 41 weeks) if 1 break week is encountered', ttt => {
       ttt.plan(1)
       const exit = expectedExitDate(new Date('2017-08-07'))
-      ttt.true(momentDayOnly(exit).isSame('2018-05-18', 'day'), 'should be Friday of 41st week')
+      ttt.true(momentDayOnly(exit).isSame(momentDayOnly('2018-05-18')), 'should be Friday of 41st week')
     })
 
     tt.test('returns Friday of (startDate + 42 weeks) if both break weeks are encountered', ttt => {
       ttt.plan(1)
       const exit = expectedExitDate(new Date('2017-05-08'))
-      ttt.true(momentDayOnly(exit).isSame('2018-02-23', 'day'), 'should be Friday of 42nd week')
+      ttt.true(momentDayOnly(exit).isSame(momentDayOnly('2018-02-23')), 'should be Friday of 42nd week')
     })
   })
 
@@ -98,13 +98,13 @@ test('src/programDates', t => {
     tt.test('returns Monday of (startDate + 6) weeks if no break weeks are encountered', ttt => {
       ttt.plan(1)
       const cancel = isaCancellationDate(new Date('2017-02-06'))
-      ttt.true(momentDayOnly(cancel).isSame('2017-03-13'), 'should be Monday of 6th week')
+      ttt.true(momentDayOnly(cancel).isSame(momentDayOnly('2017-03-13')), 'should be Monday of 6th week')
     })
 
     tt.test('returns Monday of (startDate + 7) weeks if a break week is encountered', ttt => {
       ttt.plan(1)
       const cancel = isaCancellationDate(new Date('2017-12-04'))
-      ttt.true(momentDayOnly(cancel).isSame('2018-01-15'), 'should be Monday of 6th week')
+      ttt.true(momentDayOnly(cancel).isSame(momentDayOnly('2018-01-15')), 'should be Monday of 6th week')
     })
   })
 
@@ -113,9 +113,9 @@ test('src/programDates', t => {
 
     tt.test('returns the start date of the session (0 indexed) for a given program start date', ttt => {
       ttt.plan(3)
-      ttt.true(momentDayOnly(isaSessionStartDate(new Date('2016-11-28'), 0)).isSame('2016-11-28'), 'should be Monday of 1st week, not counting break weeks')
-      ttt.true(momentDayOnly(isaSessionStartDate(new Date('2016-11-28'), 2)).isSame('2017-03-27'), 'should be Monday of 24th week, not counting break weeks')
-      ttt.true(momentDayOnly(isaSessionStartDate(new Date('2016-11-28'), 3)).isSame('2017-05-22'), 'should be Monday of 32nd week, not counting break weeks')
+      ttt.true(momentDayOnly(isaSessionStartDate(new Date('2016-11-28'), 0)).isSame(momentDayOnly('2016-11-28')), 'should be Monday of 1st week, not counting break weeks')
+      ttt.true(momentDayOnly(isaSessionStartDate(new Date('2016-11-28'), 2)).isSame(momentDayOnly('2017-03-27')), 'should be Monday of 24th week, not counting break weeks')
+      ttt.true(momentDayOnly(isaSessionStartDate(new Date('2016-11-28'), 3)).isSame(momentDayOnly('2017-05-22')), 'should be Monday of 32nd week, not counting break weeks')
     })
   })
 
@@ -124,9 +124,9 @@ test('src/programDates', t => {
 
     tt.test('returns the end date of the session (0 indexed) for a given program start date', ttt => {
       ttt.plan(3)
-      ttt.true(momentDayOnly(isaSessionEndDate(new Date('2016-11-28'), 0)).isSame('2017-01-27'), 'should be Friday of 8th week, not counting break weeks')
-      ttt.true(momentDayOnly(isaSessionEndDate(new Date('2016-11-28'), 2)).isSame('2017-05-19'), 'should be Friday of 24th week, not counting break weeks')
-      ttt.true(momentDayOnly(isaSessionEndDate(new Date('2016-11-28'), 3)).isSame('2017-07-21'), 'should be Friday of 32nd week, not counting break weeks')
+      ttt.true(momentDayOnly(isaSessionEndDate(new Date('2016-11-28'), 0)).isSame(momentDayOnly('2017-01-27')), 'should be Friday of 8th week, not counting break weeks')
+      ttt.true(momentDayOnly(isaSessionEndDate(new Date('2016-11-28'), 2)).isSame(momentDayOnly('2017-05-19')), 'should be Friday of 24th week, not counting break weeks')
+      ttt.true(momentDayOnly(isaSessionEndDate(new Date('2016-11-28'), 3)).isSame(momentDayOnly('2017-07-21')), 'should be Friday of 32nd week, not counting break weeks')
     })
   })
 
@@ -135,7 +135,7 @@ test('src/programDates', t => {
 
     tt.test('returns the number of days in the session (0 indexed) for a given program start date', ttt => {
       ttt.plan(1)
-      const numDays = numDaysInISASession(new Date('2016-10-03'), 0)
+      const numDays = numDaysInISASession(new Date(Date.UTC(2016, 9, 3)), 0) // 10/3/16
       ttt.equal(numDays, 36, 'should exclude Indigenous People\'s Day, Veteran\'s Day, and the Thanksgiving holidays')
     })
   })
@@ -145,7 +145,7 @@ test('src/programDates', t => {
 
     tt.test('returns the stipend payment dates between the given dates', ttt => {
       ttt.plan(1)
-      const payments = stipendPaymentDatesBetween(new Date('2017-08-07'), new Date('2017-12-31'))
+      const payments = stipendPaymentDatesBetween(new Date(Date.UTC(2017, 7, 7)), new Date(Date.UTC(2017, 11, 31))) // 8/7/17, 12/31/17
       ttt.equal(payments.length, 10, 'should include 10 stipend payments')
     })
   })

--- a/src/util.js
+++ b/src/util.js
@@ -6,6 +6,7 @@ export const momentDayOnly = date => {
     throw new Error(`${date} is not a valid date`)
   }
   return dayOnly
+    .utc()
     .hour(0)
     .minute(0)
     .second(0)
@@ -13,7 +14,7 @@ export const momentDayOnly = date => {
 }
 
 export const formatDate = date => {
-  return moment(date).format('ddd DD MMM YYYY')
+  return moment(date).utc().format('ddd DD MMM YYYY')
 }
 
 export const throwsIfInvalidDate = func => {


### PR DESCRIPTION
Fixes #4.

Because there was no explicit timezone conversion, dates instantiated on the production server for rendering (UTC) would differ from dates rendered on the client (mostly in Pacific time). This caused problems with dates often being displayed incorrectly.

The change converts all dates handled to UTC before using in calculaations or displaying.